### PR TITLE
feat: synchronize 이벤트 시 변경된 파일만 패턴 재분석

### DIFF
--- a/handlers/tag-patterns.js
+++ b/handlers/tag-patterns.js
@@ -23,6 +23,7 @@ const MAX_FILE_SIZE = 20000; // 20K 문자 제한 (OpenAI 토큰 안전장치)
  * @param {object} prData - PR 객체 (draft, labels 포함)
  * @param {string} appToken - GitHub App installation token
  * @param {string} openaiApiKey
+ * @param {string[]|null} [changedFilenames=null] - synchronize 시 변경된 파일명 목록 (null이면 전체 분석)
  */
 export async function tagPatterns(
   repoOwner,
@@ -31,7 +32,8 @@ export async function tagPatterns(
   headSha,
   prData,
   appToken,
-  openaiApiKey
+  openaiApiKey,
+  changedFilenames = null
 ) {
   // 2-1. Skip 조건
   if (prData.draft === true) {
@@ -58,22 +60,34 @@ export async function tagPatterns(
   }
 
   const allFiles = await filesResponse.json();
-  const solutionFiles = allFiles.filter(
+  let solutionFiles = allFiles.filter(
     (f) =>
       (f.status === "added" || f.status === "modified") &&
       SOLUTION_PATH_REGEX.test(f.filename)
   );
 
+  // changedFilenames가 제공되면 해당 파일만 대상으로 좁힘 (synchronize 최적화)
+  if (changedFilenames !== null) {
+    const changedSet = new Set(changedFilenames);
+    solutionFiles = solutionFiles.filter((f) => changedSet.has(f.filename));
+    console.log(
+      `[tagPatterns] PR #${prNumber}: narrowed to ${solutionFiles.length} changed solution files`
+    );
+  }
+
   console.log(
-    `[tagPatterns] PR #${prNumber}: ${allFiles.length} files, ${solutionFiles.length} solution files`
+    `[tagPatterns] PR #${prNumber}: ${allFiles.length} total files, ${solutionFiles.length} solution files to analyze`
   );
 
   if (solutionFiles.length === 0) {
     return { skipped: "no-solution-files" };
   }
 
-  // 2-3. 기존 Bot 패턴 태그 코멘트 삭제
-  await deletePreviousPatternComments(repoOwner, repoName, prNumber, appToken);
+  // 2-3. 기존 Bot 패턴 태그 코멘트 삭제 (변경 파일만)
+  const targetFilenames = solutionFiles.map((f) => f.filename);
+  await deletePreviousPatternComments(
+    repoOwner, repoName, prNumber, appToken, targetFilenames
+  );
 
   // 2-4. 파일별 OpenAI 분석 + 코멘트 작성 (각 파일 try/catch 래핑)
   const results = [];
@@ -101,13 +115,16 @@ export async function tagPatterns(
 }
 
 /**
- * 기존 Bot 패턴 태그 코멘트 삭제 (다른 사용자 코멘트는 절대 건드리지 않음)
+ * 기존 Bot 패턴 태그 코멘트 삭제 (대상 파일만, 다른 사용자 코멘트는 절대 건드리지 않음)
+ *
+ * @param {string[]} targetFilenames - 삭제 대상 파일명 목록
  */
 async function deletePreviousPatternComments(
   repoOwner,
   repoName,
   prNumber,
-  appToken
+  appToken,
+  targetFilenames
 ) {
   const response = await fetch(
     `https://api.github.com/repos/${repoOwner}/${repoName}/pulls/${prNumber}/comments?per_page=100`,
@@ -122,8 +139,12 @@ async function deletePreviousPatternComments(
   }
 
   const comments = await response.json();
+  const targetSet = new Set(targetFilenames);
   const botPatternComments = comments.filter(
-    (c) => c.user?.type === "Bot" && c.body?.includes(COMMENT_MARKER)
+    (c) =>
+      c.user?.type === "Bot" &&
+      c.body?.includes(COMMENT_MARKER) &&
+      targetSet.has(c.path)
   );
 
   for (const comment of botPatternComments) {
@@ -149,7 +170,7 @@ async function deletePreviousPatternComments(
   }
 
   console.log(
-    `[tagPatterns] Deleted ${botPatternComments.length} previous pattern comments`
+    `[tagPatterns] Deleted ${botPatternComments.length} previous pattern comments for ${targetFilenames.length} files`
   );
 }
 

--- a/handlers/webhooks.js
+++ b/handlers/webhooks.js
@@ -205,9 +205,34 @@ async function handleProjectsV2ItemEvent(payload, env) {
 }
 
 /**
+ * Compare API로 두 커밋 사이에 변경된 파일명 목록 조회
+ *
+ * @param {string} repoOwner
+ * @param {string} repoName
+ * @param {string} baseSha - 이전 커밋 SHA
+ * @param {string} headSha - 새 커밋 SHA
+ * @param {string} appToken
+ * @returns {Promise<string[]|null>} 변경된 파일명 배열 (실패 시 null → 전체 분석 fallback)
+ */
+async function getChangedFilenames(repoOwner, repoName, baseSha, headSha, appToken) {
+  const response = await fetch(
+    `https://api.github.com/repos/${repoOwner}/${repoName}/compare/${baseSha}...${headSha}`,
+    { headers: getGitHubHeaders(appToken) }
+  );
+
+  if (!response.ok) {
+    console.error(`[getChangedFilenames] Compare API failed: ${response.status}`);
+    return null;
+  }
+
+  const data = await response.json();
+  return (data.files || []).map((f) => f.filename);
+}
+
+/**
  * Pull Request 이벤트 처리
- * - opened/reopened: Week 설정 체크 + 알고리즘 패턴 태깅
- * - synchronize: 알고리즘 패턴 태깅만 (Week 체크 스킵 - 이미 설정됐을 가능성 높음)
+ * - opened/reopened: Week 설정 체크 + 알고리즘 패턴 태깅 (전체 파일)
+ * - synchronize: 알고리즘 패턴 태깅만 (변경된 파일만, Week 체크 스킵)
  */
 async function handlePullRequestEvent(payload, env) {
   const action = payload.action;
@@ -256,6 +281,21 @@ async function handlePullRequestEvent(payload, env) {
   // 알고리즘 패턴 태깅 (OPENAI_API_KEY 있을 때만)
   if (env.OPENAI_API_KEY) {
     try {
+      // synchronize일 때만 변경 파일 목록 추출 (최적화: #7)
+      let changedFilenames = null;
+      if (action === "synchronize" && payload.before && payload.after) {
+        changedFilenames = await getChangedFilenames(
+          repoOwner,
+          repoName,
+          payload.before,
+          payload.after,
+          appToken
+        );
+        console.log(
+          `[handlePullRequestEvent] synchronize: ${changedFilenames?.length ?? "fallback(all)"} files changed between ${payload.before.slice(0, 7)}...${payload.after.slice(0, 7)}`
+        );
+      }
+
       await tagPatterns(
         repoOwner,
         repoName,
@@ -263,7 +303,8 @@ async function handlePullRequestEvent(payload, env) {
         pr.head.sha,
         pr,
         appToken,
-        env.OPENAI_API_KEY
+        env.OPENAI_API_KEY,
+        changedFilenames
       );
     } catch (error) {
       console.error(`[handlePullRequestEvent] tagPatterns failed: ${error.message}`);


### PR DESCRIPTION
## Summary

- `synchronize` 이벤트 시 Compare API(`/compare/{before}...{after}`)로 이번 push에서 실제 변경된 파일만 식별
- 변경된 파일의 봇 코멘트만 삭제/재작성하여 불필요한 OpenAI API 호출과 GitHub 알림 스팸 방지
- Compare API 실패 시 기존 동작(전체 파일 분석)으로 안전하게 fallback

Closes #7

## Test plan

- [ ] `opened` 이벤트: 기존처럼 모든 솔루션 파일이 분석되는지 확인
- [ ] `synchronize` 이벤트: 변경된 파일만 분석되고, 미변경 파일의 봇 코멘트가 유지되는지 확인
- [ ] Compare API 실패 시 전체 파일 분석으로 fallback되는지 확인
- [ ] 실제 PR에서 재push 후 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)