### PR TITLE
fix: self-fetch 522 에러 해결을 위한 호환성 플래그 추가

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
   "name": "github",
   "main": "index.js",
   "compatibility_date": "2024-01-01",
+  "compatibility_flags": ["global_fetch_strictly_public"],
   "account_id": "94480614a6df7731f1e4491bdac5c440",
   "vars": {
     "WORKER_URL": "https://github.dalestudy.workers.dev",


### PR DESCRIPTION
커스텀 도메인에서 같은 Worker로 self-fetch 시 522가 발생하는
Cloudflare 제한을 global_fetch_strictly_public 플래그로 해제