### PR TITLE
fix: PR 파일 집계에 rename 상태 포함

### DIFF
--- a/utils/learningData.js
+++ b/utils/learningData.js
@@ -285,7 +285,7 @@ export async function fetchUserSolutions(
 
 /**
  * Fetches the files changed in a PR and returns those that match
- * {problem-name}/{username}.{ext} and are added or modified.
+ * {problem-name}/{username}.{ext} and are added, modified, or renamed.
  *
  * @param {string} repoOwner
  * @param {string} repoName
@@ -329,7 +329,12 @@ export async function fetchPRSubmissions(
   const results = [];
 
   for (const file of files) {
-    if (file.status !== "added" && file.status !== "modified") continue;
+    if (
+      file.status !== "added" &&
+      file.status !== "modified" &&
+      file.status !== "renamed"
+    )
+      continue;
 
     const match = file.filename.match(usernamePattern);
     if (match) {


### PR DESCRIPTION
## 배경

#32 에서 기수 프로젝트 기반 학습 현황 집계를 도입했는데, 실제 운용 결과 soobing(본인) 계정의 cohort 7기 누적 풀이가 **15개로 표시**됨. 기대값은 26개 (실제 풀이 문제 수).

### 원인

`fetchPRSubmissions` 가 `status === "added" || "modified"` 만 집계하는데, soobing 의 과거 PR #2556 ([파일이름 user name과 동일하게 제출하지 않은 부분 수정](https://github.com/DaleStudy/leetcode-study/pull/2556)) 은 `soobing3.ts` → `soobing.ts` rename PR. rename 된 11개 파일이 **모두 제외**되어 카운팅에서 누락됨.

> 참고: 초기 PR 4개(#2392/2431/2463/2489) 는 `soobing3.ts` 파일명으로 제출되어 정규식 `^([^/]+)/soobing\.[^/]+$` 에 매칭되지 않음. PR #2556 의 rename 이 이들을 정규식 매칭 가능한 `soobing.ts` 로 승격시키는 역할이므로, rename 을 집계해야 누락된 풀이가 복구됨.

## 변경

`utils/learningData.js::fetchPRSubmissions` 의 status 필터에 `"renamed"` 추가.

## 영향

- 재참여자/파일명 교체 이력이 있는 유저의 학습 현황 누적 풀이 수 정상화
- 정규식 매칭은 새 경로(`filename` = 새 이름) 기준으로 동작하므로, 새 이름이 `{problem}/{username}.{ext}` 패턴에 맞아야 집계됨 (의도된 동작)

## 관련

- 후속: #10 / #32

## Test plan

- [x] `bun test` — 54/54 통과 (기존 mock 에 rename 시나리오 없어 회귀 없음)
- [ ] Preview 환경에서 soobing 계정의 누적 카운트가 26으로 반영되는지 확인