### PR TITLE
fix: API 사용량 표 요청 번호에서 # 제거 (PR 자동 링크 회피)

### DIFF
--- a/tests/learningComment.test.js
+++ b/tests/learningComment.test.js
@@ -50,7 +50,7 @@ describe("upsertLearningStatusComment — usage history accumulation", () => {
 
     const body = parseBody(post);
     expect(body).toContain("🔢 API 사용량 (gpt-4.1-nano)");
-    expect(body).toContain("| #1 | 100 | 50 | 150 |");
+    expect(body).toContain("| 1 | 100 | 50 | 150 |");
     // single-row history => no totals row
     expect(body).not.toContain("**합계**");
     // hidden marker stores an array
@@ -99,9 +99,9 @@ describe("upsertLearningStatusComment — usage history accumulation", () => {
 
     const body = parseBody(patch);
     // all three calls present, in order
-    expect(body).toContain("| #1 | 100 | 50 | 150 |");
-    expect(body).toContain("| #2 | 200 | 80 | 280 |");
-    expect(body).toContain("| #3 | 300 | 120 | 420 |");
+    expect(body).toContain("| 1 | 100 | 50 | 150 |");
+    expect(body).toContain("| 2 | 200 | 80 | 280 |");
+    expect(body).toContain("| 3 | 300 | 120 | 420 |");
     // totals row appears once history.length > 1
     expect(body).toContain("| **합계** | **600** | **250** | **850** |");
     // marker is rewritten with the full array
@@ -146,7 +146,7 @@ describe("upsertLearningStatusComment — usage history accumulation", () => {
     const patch = calls.find((c) => c.init.method === "PATCH");
     const body = parseBody(patch);
 
-    expect(body).toContain("| #1 | 999 | 111 | 1,110 |");
+    expect(body).toContain("| 1 | 999 | 111 | 1,110 |");
     expect(body).not.toContain("**합계**");
 
     globalThis.fetch = originalFetch;

--- a/utils/learningComment.js
+++ b/utils/learningComment.js
@@ -84,7 +84,7 @@ function formatUsageSection(history) {
     const { prompt, completion } = history[i];
     const total = prompt + completion;
     const cost = calcCost(prompt, completion);
-    lines.push(`| #${i + 1} | ${fmt(prompt)} | ${fmt(completion)} | ${fmt(total)} | $${cost.toFixed(6)} |`);
+    lines.push(`| ${i + 1} | ${fmt(prompt)} | ${fmt(completion)} | ${fmt(total)} | $${cost.toFixed(6)} |`);
     totalPrompt += prompt;
     totalCompletion += completion;
   }


### PR DESCRIPTION
## Summary

`🔢 API 사용량` 표의 요청 번호를 `#1`, `#2`, `#3` 으로 적었더니 GitHub 가 PR/issue 자동 링크로 인식해서 실제 PR #1, PR #2 로 연결되고 있었습니다. 헤더가 이미 `요청` 이라 `#` 없이 숫자만 적어도 의미가 분명하므로 그쪽으로 정리했습니다.

- `utils/learningComment.js`: `#${i + 1}` → `${i + 1}`
- `tests/learningComment.test.js`: 표 매칭 expect 4개 갱신

## Test plan

- [x] `bun test tests/learningComment.test.js` — 4 pass
- [ ] 머지 후 실제 리트코드 PR 에서 `🔢 API 사용량` 표가 자동 링크 없이 일반 숫자로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)