### PR TITLE
OpenAI 모델을 gpt-4.1-nano에서 gpt-5-nano로 마이그레이션

### DIFF
--- a/handlers/complexity-analysis.js
+++ b/handlers/complexity-analysis.js
@@ -255,14 +255,14 @@ export async function callComplexityAnalysis(fileEntries, apiKey) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-nano",
+      model: "gpt-5-nano",
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: userPrompt },
       ],
       response_format: { type: "json_object" },
-      max_tokens: 4000,
-      temperature: 0.2,
+      max_completion_tokens: 5000,
+      reasoning_effort: "minimal",
     }),
   });
 

--- a/tests/learningComment.test.js
+++ b/tests/learningComment.test.js
@@ -49,7 +49,7 @@ describe("upsertLearningStatusComment — usage history accumulation", () => {
     expect(post).toBeDefined();
 
     const body = parseBody(post);
-    expect(body).toContain("🔢 API 사용량 (gpt-4.1-nano)");
+    expect(body).toContain("🔢 API 사용량 (gpt-5-nano)");
     expect(body).toContain("| 1 | 100 | 50 | 150 |");
     // single-row history => no totals row
     expect(body).not.toContain("**합계**");

--- a/tests/tag-patterns.test.js
+++ b/tests/tag-patterns.test.js
@@ -65,7 +65,7 @@ function makePrData(overrides = {}) {
 
 /**
  * 두 OpenAI 엔드포인트(패턴 분석 N콜 + 복잡도 분석 1콜)를 분기한다.
- * 복잡도 호출은 system_prompt 에 "복잡도" 가 포함되거나 max_tokens >= 1000 으로 식별.
+ * 복잡도 호출은 system_prompt 에 "시간/공간 복잡도를 분석" 이 포함되는지로 식별.
  */
 function makeFetchMock({
   solutionFiles,

--- a/utils/learningComment.js
+++ b/utils/learningComment.js
@@ -20,8 +20,8 @@ const COMMENT_MARKER = "<!-- dalestudy-learning-status -->";
  */
 const USAGE_DATA_RE = /<!-- usage-data: (\[.*?\]) -->/;
 
-/** gpt-4.1-nano pricing (USD per token) */
-const INPUT_COST_PER_TOKEN = 0.10 / 1_000_000;
+/** gpt-5-nano pricing (USD per token) */
+const INPUT_COST_PER_TOKEN = 0.05 / 1_000_000;
 const OUTPUT_COST_PER_TOKEN = 0.40 / 1_000_000;
 
 /**
@@ -72,7 +72,7 @@ function parseUsageFromComment(body) {
 function formatUsageSection(history) {
   const lines = [];
   lines.push("<details>");
-  lines.push("<summary>🔢 API 사용량 (gpt-4.1-nano)</summary>");
+  lines.push("<summary>🔢 API 사용량 (gpt-5-nano)</summary>");
   lines.push("");
   lines.push("| 요청 | 입력 토큰 | 출력 토큰 | 합계 | 비용 |");
   lines.push("|---:|---:|---:|---:|---:|");

--- a/utils/openai.js
+++ b/utils/openai.js
@@ -37,7 +37,11 @@ PR의 코드 변경 사항을 참고하여 사용자의 질문에 명확하고 �
 
 단순히 지적만 하지 말고, 격려와 학습이 되는 피드백을 함께 주세요.
 해당 사항없는 항목은 생략하고 자연스럽게 작성하세요.
-500 글자를 초과하지 말아주세요.
+
+[작성 규칙 — 반드시 지킬 것]
+- 전체 응답은 한국어 기준 500자 이내. 절대 초과하지 마세요. 분량이 넘칠 것 같으면 가장 중요한 피드백만 남기고 나머지는 생략하세요.
+- 한국어로만 작성하세요. 중국어·일본어 한자나 다른 언어를 섞지 마세요(예: "一致" 금지, "일치" 사용).
+- 항목은 3개 이내로 압축하고, 장황한 설명 없이 핵심만 간결하게 쓰세요.
 `;
 
   let userPrompt = `# PR Title
@@ -65,13 +69,13 @@ ${prDiff}
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-nano",
+      model: "gpt-5-nano",
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
-      max_tokens: 2000,
-      temperature: 0.7,
+      max_completion_tokens: 3000,
+      reasoning_effort: "minimal",
     }),
   });
 
@@ -143,14 +147,14 @@ ${fileContent}
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-nano",
+      model: "gpt-5-nano",
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
       response_format: { type: "json_object" },
-      max_tokens: 500,
-      temperature: 0.3,
+      max_completion_tokens: 2000,
+      reasoning_effort: "minimal",
     }),
   });
 
@@ -221,14 +225,14 @@ ${truncatedContent}
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-nano",
+      model: "gpt-5-nano",
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
       response_format: { type: "json_object" },
-      max_tokens: 200,
-      temperature: 0.2,
+      max_completion_tokens: 1500,
+      reasoning_effort: "minimal",
     }),
   });
 


### PR DESCRIPTION
PR 코드 분석에 쓰는 OpenAI 모델을 `gpt-4.1-nano`에서 입력 단가가 절반인 신 모델인 `gpt-5-nano`로 교체했습니다. GPT 5 부터는 reasoning 모델이라 temperature와 같은 기존 파라미터를 그대로 쓰면 400 에러가 나기 때문에 관련해서 수정하였습니다.

사용량 비용을 표시할 때 하드코딩 단가와 라벨도 새 모델 기준으로 맞췄습니다. 추가로, 실제 호출 검증 중 GPT 5가 코드 리뷰 길이 제약을 덜 지키고 간혹 한자를 섞는 경향이 보여 코드 리뷰 시스템 프롬프트에 "500자 이내, 한국어 전용" 규칙을 강화했습니다.

실제 로컬에서 임시로 OpenAI API 키를 발급받아 JSON 준수, 파라미터 호환을 검증하였습니다.